### PR TITLE
Fix relative require paths

### DIFF
--- a/file_listener.js
+++ b/file_listener.js
@@ -3,7 +3,7 @@ var variables = result.parsed
 
 var Airtable = require('airtable');
 
-const airtable = require(__dirname + "\\airtable_object.js")
+const airtable = require("./airtable_object.js")
 const clone = require('rfdc')()
 const directories = []
 for (variable in servers["local_servers"]) {
@@ -64,7 +64,7 @@ async function run_data(data){
     var object = JSON.parse(data)
     switch(object.type){
         case "Started_game":
-            var json = clone(require(__dirname + "\\score_template.json"));
+            var json = clone(require("./score_template.json"));
             var player_ids = []
             for (player of object.players ){
                 player_ids.push( await airtable.get_player_id(player))
@@ -83,7 +83,7 @@ async function run_data(data){
 
         case "end_game":
             var current_timeDate = new Date(get_date())
-            var json = clone(require(__dirname + "\\score_update_template.json"));
+            var json = clone(require("./score_update_template.json"));
             var players
             json[0].id = airtable_id
             await Promise.all([airtable.get_player_id(object.Gold), airtable.get_player_id(object.Silver), airtable.get_player_id(object.Bronze)]).then((values) => {

--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ var variables = result.parsed
 global.key  = variables.Api_key
 servers =  JSON.parse((variables.Servers))
 global.servers = servers
-require(__dirname + "\\file_listener.js")
+require("./file_listener.js")
 
 Rcon = require("rcon-client").Rcon
 async function connect_rcon(port,pw){


### PR DESCRIPTION
Concatenating `__dirname` with `\path.js` does not work on Linux (path is separated with / there).  The standard way of requiring relative files in Node.js is with `./relative/path.js` and works on both platforms.