### PR TITLE
Server_address removal and file_listener fix

### DIFF
--- a/client.js
+++ b/client.js
@@ -67,9 +67,6 @@ async function server_connected(ip, server) {
         await server.rcon.send(`/interface global.servers = {lobby = '${lobby_ip}'}`);
     }
 
-    //Set the ip:port of the server so the server know who it is.
-    await server.rcon.send(`/set_server_address ${ip}`);
-
     //Get all mini games the server can run
     let result = await server.rcon.send(`/interface
         local result = {}

--- a/file_listener.js
+++ b/file_listener.js
@@ -26,7 +26,10 @@ exports.watch_files = function(servers) {
 
             fs.promises.readFile(path.join(dir, filename)).then(content => {
                 let object = JSON.parse(content);
-                file_events.emit(object.type, server, object);
+                if (!file_events.emit(object.type, server, object)) {
+                    console.log(`Warning: Unhandled file event ${object.type}`);
+                    console.log(object);
+                }
             }).catch(err => {
                 console.error(`Error reading ${filename} for ${ip}:`, err);
             });

--- a/server.js
+++ b/server.js
@@ -149,9 +149,6 @@ async function server_connected(ip, server) {
     //telling the server if this the lobby
     await server.rcon.send(`/set_lobby ${server.is_lobby}`);
 
-    //telling the server its own ip
-    await server.rcon.send(`/set_server_address ${ip}`);
-
     //if the server is the lobby log it and continue as the lobby cant have games
     if (server.is_lobby) {
         console.log(`${ip} is the lobby. `);


### PR DESCRIPTION
Removes setting `server_address` as it's not needed (lua side removal at explosivegaming/factorio-olympics#16) and fix the file_listener sending out duplicate events on Windows by adding a delay to reading the file.