### PR TITLE
Store all results in Airtable

### DIFF
--- a/factorio_server.js
+++ b/factorio_server.js
@@ -1,4 +1,6 @@
 "use strict";
+const fs = require('fs').promises;
+
 const client = require('./client.js');
 const file_listener = require('./file_listener.js');
 const rcon_connector = require('./rcon_connector.js');


### PR DESCRIPTION
Implementation of storing all the results in the Airtable in a separate Match Scores table.  The following changes is needed to the Airtable to make this work:
- Rename Scoring Data table to Matches and remove the Gold/Sliver/Bronze player and data columns.
- Create a Score Data table with the columns Match, Place, Players, Score, and Extra.